### PR TITLE
Automatically run tests when code changes TG-85

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -3,5 +3,6 @@
     "babel-register"
   ],
   "sourceMap": false,
-  "instrument": false
+  "instrument": false,
+  "report-dir": "./docs/coverage"
 }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -137,12 +137,14 @@ test or production mode.
 
 Useful scripts for day-to-day development.
 
-| Script               | Purpose                                                                            |
-| :---                 | :---                                                                               |
-| `npm run dev`        | Run the server and open the project's documentation with live reload               |
-| `npm run dev:docs`   | Generate the project's documentation and opens it in your browser with live reload |
-| `npm run dev:server` | Run the server in development mode with live reload                                |
-| `npm start`          | Run the server                                                                     |
+| Script               | Purpose                                                                                                                    |
+| :---                 | :---                                                                                                                       |
+| `npm run dev`        | Run the server and open the project's documentation with live reload                                                       |
+| `npm run dev:all`    | Run the server, open the project's documentation with live reload, and automatically run automated tests when code changes |
+| `npm run dev:docs`   | Generate the project's documentation and opens it in your browser with live reload                                         |
+| `npm run dev:server` | Run the server in development mode with live reload                                                                        |
+| `npm run dev:test`   | Run the automated tests and automatically re-runs them when code changes                                                   |
+| `npm start`          | Run the server                                                                                                             |
 
 ### Database scripts
 
@@ -178,11 +180,12 @@ See the [Documentation](#documentation) section for more information.
 
 See the [Testing](#testing) section for more information.
 
-| Script                   | Purpose                                                                                        |
-| :---                     | :---                                                                                           |
-| `npm test`               | Run all automated tests                                                                        |
-| `npm run test:coveralls` | Send test coverage data to [Coveralls][coveralls] (used on Travis CI)                          |
-| `npm run test:debug`     | Run all automated tests with `$LOG_LEVEL` set to `TRACE` (all database queries will be logged) |
+| Script                        | Purpose                                                                                        |
+| :---                          | :---                                                                                           |
+| `npm test`                    | Run all automated tests                                                                        |
+| `npm run test:coveralls`      | Send test coverage data to [Coveralls][coveralls] (used on Travis CI)                          |
+| `npm run test:debug`          | Run all automated tests with `$LOG_LEVEL` set to `TRACE` (all database queries will be logged) |
+| `npm run test:watch`          | Watch code for changes and automatically run the automated tests when it changes               |
 
 ### Utility scripts
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,15 +38,20 @@
             <p>Detailed documentation, guidelines and best practices.</p>
             <p><a class="btn btn-secondary" href="https://github.com/MediaComem/biopocket-backend/blob/master/DEVELOPMENT.md" role="button">Read the docs on GitHub &raquo;</a></p>
           </div>
-          <div class="col-md-6">
+          <div class="col-md-4">
             <h2>REST API</h2>
             <p>How to query the REST API.</p>
             <p><a class="btn btn-secondary" href="/api" role="button">Read the API docs &raquo;</a></p>
           </div>
-          <div class="col-md-6">
+          <div class="col-md-4">
             <h2>Source Code</h2>
             <p>How to use the code in the Node.js Express application.</p>
             <p><a class="btn btn-secondary" href="/src" role="button">Read the JSDoc &raquo;</a></p>
+          </div>
+          <div class="col-md-4">
+            <h2>Test Coverage</h2>
+            <p>Which sections of the code are in need of more tests.</p>
+            <p><a class="btn btn-secondary" href="/coverage" role="button">Read the coverage report &raquo;</a></p>
           </div>
         </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7837,6 +7837,70 @@
         "raml2html-default-theme": "2.5.0",
         "raml2obj": "5.7.0",
         "yargs": "7.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          }
+        }
       }
     },
     "raml2html-default-theme": {
@@ -9240,12 +9304,6 @@
         "isexe": "2.0.0"
       }
     },
-    "which-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-      "dev": true
-    },
     "widest-line": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
@@ -9424,72 +9482,6 @@
       "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.35.tgz",
       "integrity": "sha1-DIUs73jNAjHRtqejZTmWjlALOIw=",
       "dev": true
-    },
-    "yargs": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-      "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-      "dev": true,
-      "requires": {
-        "camelcase": "3.0.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "5.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-      "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-      "dev": true,
-      "requires": {
-        "camelcase": "3.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        }
-      }
     },
     "z-schema": {
       "version": "3.19.0",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
     "anonymize": "node scripts/anonymize.js",
     "create-admin": "node scripts/create-admin.js",
     "dev": "concurrently \"npm run dev:docs\" \"npm run dev:server\"",
+    "dev:all": "concurrently \"npm run dev:docs\" \"npm run dev:server\" \"npm run dev:test\"",
     "dev:docs": "npm run docs && concurrently \"npm run docs:serve\" \"npm run docs:watch\"",
     "dev:server": "nodemon",
+    "dev:test": "npm test && npm run test:watch",
     "docs": "npm run docs:clean && concurrently \"npm run docs:api\" \"npm run docs:src\"",
     "docs:api": "mkdirp docs/api && raml2html -i server/api/index.raml -o docs/api/index.html",
     "docs:api:clean": "rimraf docs/api",
@@ -28,7 +30,8 @@
     "start": "node ./bin/www",
     "test": "cross-env NODE_ENV=test BCRYPT_COST=1 LOG_LEVEL=WARN nyc --reporter=html --reporter=text mocha --reporter=mocha-api-errors server/**/*.spec.js",
     "test:coveralls": "nyc report --reporter=text-lcov | coveralls",
-    "test:debug": "cross-env NODE_ENV=test BCRYPT_COST=1 LOG_LEVEL=TRACE nyc --reporter=html --reporter=text mocha --reporter=mocha-api-errors server/**/*.spec.js"
+    "test:debug": "cross-env NODE_ENV=test BCRYPT_COST=1 LOG_LEVEL=TRACE nyc --reporter=html --reporter=text mocha --reporter=mocha-api-errors server/**/*.spec.js",
+    "test:watch": "onchange \"server/**/*.js\" -- npm test"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/scripts/serve-docs.js
+++ b/scripts/serve-docs.js
@@ -1,18 +1,47 @@
-const _ = require('lodash');
 const getPort = require('get-port');
 const liveServer = require('live-server');
+const _ = require('lodash');
 
 const config = require('../config');
 
+const logger = config.logger('scripts:serve-docs');
+
+/**
+ * Serves the documentation directory in the browser with live reload.
+ *
+ * A free random port is found by default, unless a specific port has been
+ * configured.
+ */
 Promise
   .resolve()
   .then(getDocsPort)
-  .then(serveDocs);
+  .then(serveDocs)
+  .catch(err => logger.fatal(err));
 
+/**
+ * Returns the port configured to serve the documentation directory, or a free
+ * random port.
+ *
+ * @returns {Promise<number>} A promise that will be resolved with a free port
+ *   number (or rejected if no free port can be found).
+ */
 function getDocsPort() {
   return config.docs.port ? Promise.resolve(config.docs.port) : getPort();
 }
 
+/**
+ * Serves the documentation directory in the browser on the specified port using
+ * live-server.
+ *
+ * The following configuration can also be customized:
+ *
+ * * The `config.docs.host` property determines the host to serve the
+ *   documentation on (`localhost` by default).
+ * * The `config.docs.open` property determines whether to automatically open
+ *   the browser or not (true by default).
+ *
+ * @param {number} port - The port to run live-server on.
+ */
 function serveDocs(port) {
 
   const liveServerConfig = {
@@ -21,7 +50,7 @@ function serveDocs(port) {
     host: config.docs.host,
     open: config.docs.open,
     port: port,
-    root: './docs',
+    root: config.path('docs'),
     wait: 50
   };
 


### PR DESCRIPTION
3 new npm scripts:

* `npm run dev:test` runs the tests and then re-runs them every time the
  code changes. This is not automatically launched when running `npm run
  dev`, because reading the test output mixed with the documentation
  generation output is not humanly possible.
* `npm run dev:all` does `npm run dev` + `npm run dev:test`, in case you
  are superhuman and want to do it anyway.
* `npm run test:watch` to automatically run the tests when code changes.

nyc has been configured to save its test coverage report in
`docs/coverage` rather than `coverage`, that way the coverage report is
in the same directory as the rest of the documentation, and is served
along with the API & source code documentation. A link to the coverage
report has been added to the documentation's home page.