### PR TITLE
Add bounding box filter to `GET /api/locations`

### DIFF
--- a/scripts/sample-data.js
+++ b/scripts/sample-data.js
@@ -1,4 +1,13 @@
+const Location = require('../server/models/location');
+const locationFixtures = require('../server/spec/fixtures/location');
 const Script = require('./script');
+
+const LOCATIONS_COUNT = 50;
+
+const ONEX_BBOX = {
+  southWest: [ 6.086417, 46.173987 ],
+  northEast: [ 6.112753, 46.196898 ]
+};
 
 /**
  * Script to generate sample data for development.
@@ -19,11 +28,22 @@ class SampleDataScript extends Script {
 
     this.start = new Date().getTime();
 
+    // Create an admin user.
     process.env.ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
     process.env.ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'test';
     process.env.NO_SCRIPT = true;
-
     await require('./create-admin').run();
+
+    // Make sure there are at least 50 locations in the database.
+    // If not, generate new random locations in Onex until there are 50 in total.
+    const locationsCount = await new Location().resetQuery().count();
+    if (locationsCount < LOCATIONS_COUNT) {
+      await Promise.all(new Array(LOCATIONS_COUNT - locationsCount).fill(0).map(() => locationFixtures.location({
+        bbox: ONEX_BBOX
+      })));
+    } else {
+      this.logger.debug(`There are already ${LOCATIONS_COUNT} locations or more in the database`);
+    }
   }
 
   onSuccess() {

--- a/server/api/locations/locations.api.spec.js
+++ b/server/api/locations/locations.api.spec.js
@@ -418,9 +418,9 @@ describe('Locations API', function() {
       let locations;
       beforeEach(async function() {
         locations = await Promise.all([
-          locationFixtures.location({ name: 'Location A - Somewhere', geometry: geoJsonFixtures.point({ coordinates: [ 10, 20 ] }) }),
-          locationFixtures.location({ name: 'Location C - Somewhere else', geometry: geoJsonFixtures.point({ coordinates: [ 20, 30 ] }) }),
-          locationFixtures.location({ name: 'Location B - Wheeeeeeee', geometry: geoJsonFixtures.point({ coordinates: [ 30, 40 ] }) })
+          locationFixtures.location({ name: 'Location A - Somewhere', geometry: geoJsonFixtures.point({ bbox: { southWest: [ 9, 19 ], northEast: [ 11, 21 ] } }) }),
+          locationFixtures.location({ name: 'Location C - Somewhere else', geometry: geoJsonFixtures.point({ bbox: { southWest: [ 19, 29 ], northEast: [ 21, 31 ] } }) }),
+          locationFixtures.location({ name: 'Location B - Somewhere precise', geometry: geoJsonFixtures.point({ coordinates: [ 30, 40 ] }) })
         ]);
       });
 

--- a/server/api/locations/locations.raml
+++ b/server/api/locations/locations.raml
@@ -94,6 +94,18 @@ post:
 # GET /api/locations
 get:
   description: List locations.
+  queryParameters:
+    bbox:
+      description: |
+        A bounding box within which all the returned locations should be.
+
+        The value must be composed of 4 comma-separated numbers:
+
+        * The first 2 numbers are the coordinates (longitude & latitude) of the bounding box's **south-west** corner.
+        * The last 2 numbers are the coordinates (longitude & latitude) of the bounding box's **north-east** corner.
+      required: false
+      type: number[]
+      example: '?bbox=10,20,30,40'
   responses:
     200:
       description: The locations were successfully listed.

--- a/server/api/utils/filters.js
+++ b/server/api/utils/filters.js
@@ -1,0 +1,39 @@
+/**
+ * @module server/api/utils/filters
+ */
+
+/**
+ * Modifies a database query so that it returns only records with a `geometry`
+ * that is inside the specified bounding box.
+ *
+ *     const { bbox } = require('../utils/filters');
+ *
+ *     let query = new MyModelWithGeometry();
+ *
+ *     query = bbox(query, '10,20,30,40');
+ *
+ * @param {Query} query - A Bookshelf database query.
+ * @param {string} bboxString - A bounding box string (4 comma-separated numbers).
+ * @returns {Query} The updated query.
+ */
+exports.bbox = function(query, bboxString) {
+
+  const bbox = bboxString.split(',').map(value => parseFloat(value));
+
+  const southWest = [ bbox[0], bbox[1] ];
+  const southEast = [ bbox[2], bbox[1] ];
+  const northEast = [ bbox[2], bbox[3] ];
+  const northWest = [ bbox[0], bbox[3] ];
+
+  const polygon = `POLYGON((${
+    [
+      southWest.join(' '),
+      southEast.join(' '),
+      northEast.join(' '),
+      northWest.join(' '),
+      southWest.join(' ')
+    ].join(', ')
+  }))`;
+
+  return query.query(builder => builder.whereRaw(`ST_Within(geometry, ST_GeomFromText('${polygon}', 4326))`));
+};

--- a/server/api/utils/validation.js
+++ b/server/api/utils/validation.js
@@ -39,7 +39,7 @@ exports.dsl = dsl;
  */
 exports.validateValue = function(value, status, ...callbacks) {
   if (!_.isInteger(status) || status < 100 || status > 599) {
-    throw new Error(`Status must be an HTTP status code between 100 and 599, got ${status} (type ${typeof(status)})`);
+    throw new Error(`Status must be an HTTP status code between 100 and 599, got ${_.isFinite(status) ? status : typeof(status)}`);
   } else if (!callbacks.length) {
     throw new Error('At least one callback is required');
   } else if (_.find(callbacks, (c) => !_.isFunction(c))) {
@@ -50,7 +50,7 @@ exports.validateValue = function(value, status, ...callbacks) {
     return this.validate(this.value(value), this.while(this.noError(this.atCurrentLocation())), ...callbacks);
   }).catch(function(err) {
     if (err.errors && !_.has(err, 'status')) {
-      err.status = status || 422;
+      err.status = status;
     }
 
     return Promise.reject(err);

--- a/server/api/utils/validation.js
+++ b/server/api/utils/validation.js
@@ -18,6 +18,7 @@ const dsl = valdsl();
 // Add our custom validators to the DSL.
 dsl.dsl.extend(genericValidators);
 dsl.dsl.extend({
+  bboxString: geoJsonValidators.bboxString,
   geoJsonPoint: geoJsonValidators.point
 });
 
@@ -37,7 +38,9 @@ exports.dsl = dsl;
  *   failed.
  */
 exports.validateValue = function(value, status, ...callbacks) {
-  if (!callbacks.length) {
+  if (!_.isInteger(status) || status < 100 || status > 599) {
+    throw new Error(`Status must be an HTTP status code between 100 and 599, got ${status} (type ${typeof(status)})`);
+  } else if (!callbacks.length) {
     throw new Error('At least one callback is required');
   } else if (_.find(callbacks, (c) => !_.isFunction(c))) {
     throw new Error('Additional arguments must be functions');

--- a/server/api/utils/validation.spec.js
+++ b/server/api/utils/validation.spec.js
@@ -1,0 +1,53 @@
+const { expect } = require('../../spec/utils');
+const utils = require('./validation');
+
+describe('Validation Utils', () => {
+
+  const validateValue = utils.validateValue;
+
+  describe('validateValue', () => {
+    it('should set the status of the validation error to a default value', async () => {
+
+      let validationError;
+      await validateValue('foo', 422, () => {
+        let error = new Error('validation error');
+        error.errors = [ { message: 'bug' } ];
+        throw error;
+      }).catch(err => validationError = err);
+
+      expect(validationError).to.be.an.instanceof(Error);
+      expect(validationError.message).to.equal('validation error');
+      expect(validationError.errors).to.eql([ { message: 'bug' } ]);
+      expect(validationError.status).to.equal(422);
+    });
+
+    it('should not change the status of a non-validation error', async () => {
+
+      let nonValidationError;
+      await validateValue('foo', 422, () => {
+        let error = new Error('authorization error');
+        error.status = 403;
+        throw error;
+      }).catch(err => nonValidationError = err);
+
+      expect(nonValidationError).to.be.an.instanceof(Error);
+      expect(nonValidationError.message).to.equal('authorization error');
+      expect(nonValidationError.status).to.equal(403);
+    });
+
+    it('should not accept an invalid status code', () => {
+      expect(() => validateValue('foo', undefined, () => {})).to.throw('Status must be an HTTP status code between 100 and 599, got undefined');
+      expect(() => validateValue('foo', () => {})).to.throw('Status must be an HTTP status code between 100 and 599, got function');
+      expect(() => validateValue('foo', -200, () => {})).to.throw('Status must be an HTTP status code between 100 and 599, got -200');
+      expect(() => validateValue('foo', 1000, () => {})).to.throw('Status must be an HTTP status code between 100 and 599, got 1000');
+    });
+
+    it('should require at least one callback', () => {
+      expect(() => validateValue('foo', 422)).to.throw('At least one callback is required');
+    })
+
+    it('should require all callbacks to be functions', () => {
+      expect(() => validateValue('foo', 422, () => {}, 'bar')).to.throw('Additional arguments must be functions');
+    });
+  });
+});

--- a/server/api/validators/generic.js
+++ b/server/api/validators/generic.js
@@ -80,3 +80,23 @@ exports.properties = function(...properties) {
     }
   };
 };
+
+/**
+ * Returns a ValDSL function that changes the validated value from an Express request object to one of its query parameters.
+ *
+ * @param {string} param - The name of the query parameter to validate.
+ * @returns {function} A validator function.
+ */
+exports.query = function navigateToQueryParameter(param) {
+  return function(ctx) {
+
+    const request = ctx.get('value');
+
+    ctx.set({
+      type: 'query',
+      location: param,
+      value: request.query[param],
+      valueSet: _.has(request.query, param)
+    });
+  };
+};

--- a/server/api/validators/geojson.js
+++ b/server/api/validators/geojson.js
@@ -104,7 +104,7 @@ function validateBboxStringCoordinate(ctx, coordinates, i, callback) {
       value: coordinates[i]
     });
 
-    return callback(coordinateCtx, i);
+    return callback(coordinateCtx);
   });
 }
 

--- a/server/api/validators/geojson.js
+++ b/server/api/validators/geojson.js
@@ -4,6 +4,50 @@
 const _ = require('lodash');
 
 /**
+ * Returns a ValDSL validator that checks whether a value is a well-formatted bounding box string.
+ *
+ * A bounding box string is composed of 4 comma-separated numbers:
+ *
+ * * The first 2 numbers are the coordinates (longitude & latitude) of the bounding box's south-west corner.
+ * * The last 2 numbers are the coordinates (longitude & latitude) of the bounding box's north-east corner.
+ *
+ * @returns {function} A validator function.
+ */
+exports.bboxString = function() {
+  return async function(ctx) {
+
+    // Make sure the value is a string.
+    const bbox = ctx.get('value');
+    if (!_.isString(bbox)) {
+      return ctx.addError({
+        validator: 'bboxString',
+        cause: 'wrongType',
+        message: 'must be a string'
+      })
+    }
+
+    // Make sure it has 4 values.
+    const coordinates = bbox.split(',').map(value => parseFloat(value));
+    if (coordinates.length != 4) {
+      return ctx.addError({
+        validator: 'bboxString',
+        cause: 'wrongLength',
+        actualLength: coordinates.length,
+        message: `must have 4 comma-separated coordinates; got ${coordinates.length}`
+      });
+    }
+
+    // Make sure the 4 values are valid longitudes and latitudes.
+    await Promise.all([
+      validateBboxStringCoordinate(ctx, coordinates, 0, coordinateCtx => validateLongitude(coordinateCtx)),
+      validateBboxStringCoordinate(ctx, coordinates, 1, coordinateCtx => validateLatitude(coordinateCtx)),
+      validateBboxStringCoordinate(ctx, coordinates, 2, coordinateCtx => validateLongitude(coordinateCtx)),
+      validateBboxStringCoordinate(ctx, coordinates, 3, coordinateCtx => validateLatitude(coordinateCtx))
+    ]);
+  };
+};
+
+/**
  * Returns a ValDSL validator that checks whether a value is a GeoJSON object of type Point.
  *
  *     const { point: validateGeoJsonPoint } = require('../validators/geojson');
@@ -50,6 +94,20 @@ exports.point = function() {
   };
 }
 
+function validateBboxStringCoordinate(ctx, coordinates, i, callback) {
+  return ctx.validate(coordinateCtx => {
+
+    // Make the error indicate the index of the invalid coordinate
+    // within the bbox string, e.g. "bbox[1]".
+    coordinateCtx.set({
+      location: `${coordinateCtx.get('location')}[${i}]`,
+      value: coordinates[i]
+    });
+
+    return callback(coordinateCtx, i);
+  });
+}
+
 function validateCoordinates(ctx) {
   const coordinates = ctx.get('value');
   if (!_.isArray(coordinates) || coordinates.length != 2) {
@@ -62,7 +120,7 @@ function validateCoordinates(ctx) {
 
 function validateLongitude(ctx) {
   const longitude = ctx.get('value');
-  if (typeof(longitude) != 'number' || longitude < -180 || longitude > 180) {
+  if (!_.isFinite(longitude) || longitude < -180 || longitude > 180) {
     ctx.addError({
       validator: 'longitude',
       message: 'must be a number between -180 and 180'
@@ -72,7 +130,7 @@ function validateLongitude(ctx) {
 
 function validateLatitude(ctx) {
   const latitude = ctx.get('value');
-  if (typeof(latitude) != 'number' || latitude < -90 || latitude > 90) {
+  if (!_.isFinite(latitude) || latitude < -90 || latitude > 90) {
     ctx.addError({
       validator: 'latitude',
       message: 'must be a number between -90 and 90'

--- a/server/api/validators/geojson.spec.js
+++ b/server/api/validators/geojson.spec.js
@@ -25,7 +25,6 @@ describe('GeoJSON validators', function() {
 
     it('should add an error if the bounding box is not a string', async function() {
       const err = await validate(10203040);
-      expect(err).not.to.equal(undefined);
       expectErrors(err, [
         {
           cause: 'wrongType',
@@ -40,7 +39,6 @@ describe('GeoJSON validators', function() {
 
     it('should add an error if the bounding box has the wrong number of coordinates', async function() {
       const err = await validate('10,20,30');
-      expect(err).not.to.equal(undefined);
       expectErrors(err, [
         {
           cause: 'wrongLength',
@@ -56,7 +54,6 @@ describe('GeoJSON validators', function() {
 
     it('should add an error if one of the coordinates is not a number', async function() {
       const err = await validate('10,asd,30,40');
-      expect(err).not.to.equal(undefined);
       expectErrors(err, [
         {
           location: 'bbox[1]',
@@ -143,7 +140,6 @@ describe('GeoJSON validators', function() {
 
       const err = await validate(point);
 
-      expect(err).not.to.equal(undefined);
       expectErrors(err, [
         {
           cause: 'missingProperties',
@@ -176,7 +172,6 @@ describe('GeoJSON validators', function() {
 
       const err = await validate(point);
 
-      expect(err).not.to.equal(undefined);
       expectErrors(err, [
         {
           cause: 'extraProperties',
@@ -199,7 +194,6 @@ describe('GeoJSON validators', function() {
 
       const err = await validate(point);
 
-      expect(err).not.to.equal(undefined);
       expectErrors(err, [
         {
           message: 'must be of type array',
@@ -222,7 +216,6 @@ describe('GeoJSON validators', function() {
 
       const err = await validate(point);
 
-      expect(err).not.to.equal(undefined);
       expectErrors(err, [
         {
           message: 'must be an array of 2 numbers (longitude & latitude)',
@@ -244,7 +237,6 @@ describe('GeoJSON validators', function() {
 
       const err = await validate(point);
 
-      expect(err).not.to.equal(undefined);
       expectErrors(err, [
         {
           message: 'must be an array of 2 numbers (longitude & latitude)',
@@ -266,7 +258,6 @@ describe('GeoJSON validators', function() {
 
       const err = await validate(point);
 
-      expect(err).not.to.equal(undefined);
       expectErrors(err, [
         {
           message: 'must be of type number',
@@ -289,7 +280,6 @@ describe('GeoJSON validators', function() {
 
       const err = await validate(point);
 
-      expect(err).not.to.equal(undefined);
       expectErrors(err, [
         {
           message: 'must be a number between -180 and 180',
@@ -311,7 +301,6 @@ describe('GeoJSON validators', function() {
 
       const err = await validate(point);
 
-      expect(err).not.to.equal(undefined);
       expectErrors(err, [
         {
           message: 'must be of type number',
@@ -334,7 +323,6 @@ describe('GeoJSON validators', function() {
 
       const err = await validate(point);
 
-      expect(err).not.to.equal(undefined);
       expectErrors(err, [
         {
           message: 'must be a number between -90 and 90',
@@ -360,6 +348,7 @@ describe('GeoJSON validators', function() {
 });
 
 function expectErrors(validationError, expectedErrors) {
+  expect(validationError).not.to.equal(undefined);
   const actualErrors = validationError.errors.map(err => _.omit(err, 'stack'));
   expect(actualErrors).to.have.objects(expectedErrors);
 }

--- a/server/api/validators/geojson.spec.js
+++ b/server/api/validators/geojson.spec.js
@@ -6,6 +6,113 @@ const geoJsonValidators = require('./geojson');
 
 describe('GeoJSON validators', function() {
 
+  describe('bboxString', function() {
+
+    const validateBboxString = geoJsonValidators.bboxString;
+
+    it('should be a function', function() {
+      expect(validateBboxString).to.be.a('function');
+    });
+
+    it('should create a validator function', function() {
+      expect(validateBboxString()).to.be.a('function');
+    });
+
+    it('should add no error for a valid bounding box', async function() {
+      const err = await validate('10,20,30,40');
+      expect(err).to.equal(undefined);
+    });
+
+    it('should add an error if the bounding box is not a string', async function() {
+      const err = await validate(10203040);
+      expect(err).not.to.equal(undefined);
+      expectErrors(err, [
+        {
+          cause: 'wrongType',
+          location: 'bbox',
+          message: 'must be a string',
+          validator: 'bboxString',
+          value: 10203040,
+          valueSet: true
+        }
+      ]);
+    });
+
+    it('should add an error if the bounding box has the wrong number of coordinates', async function() {
+      const err = await validate('10,20,30');
+      expect(err).not.to.equal(undefined);
+      expectErrors(err, [
+        {
+          cause: 'wrongLength',
+          actualLength: 3,
+          location: 'bbox',
+          message: 'must have 4 comma-separated coordinates; got 3',
+          validator: 'bboxString',
+          value: '10,20,30',
+          valueSet: true
+        }
+      ]);
+    });
+
+    it('should add an error if one of the coordinates is not a number', async function() {
+      const err = await validate('10,asd,30,40');
+      expect(err).not.to.equal(undefined);
+      expectErrors(err, [
+        {
+          location: 'bbox[1]',
+          message: 'must be a number between -90 and 90',
+          validator: 'latitude',
+          value: NaN,
+          valueSet: true
+        }
+      ]);
+    });
+
+    // Generate 8 tests to check the longitude/latitude bounds.
+    [
+      { index: 0, value: -190, problem: 'the longitude of the south-west corner is too small', message: 'must be a number between -180 and 180', validator: 'longitude' },
+      { index: 0, value: 213.4, problem: 'the longitude of the south-west corner is too large', message: 'must be a number between -180 and 180', validator: 'longitude' },
+      { index: 1, value: -91, problem: 'the latitude of the south-west corner is too small', message: 'must be a number between -90 and 90', validator: 'latitude' },
+      { index: 1, value: 90.001, problem: 'the latitude of the south-west corner is too large', message: 'must be a number between -90 and 90', validator: 'latitude' },
+      { index: 2, value: -180.5, problem: 'the longitude of the north-east corner is too small', message: 'must be a number between -180 and 180', validator: 'longitude' },
+      { index: 2, value: 181, problem: 'the longitude of the north-east corner is too large', message: 'must be a number between -180 and 180', validator: 'longitude' },
+      { index: 3, value: -180, problem: 'the latitude of the north-east corner is too small', message: 'must be a number between -90 and 90', validator: 'latitude' },
+      { index: 3, value: 1000, problem: 'the latitude of the north-east corner is too large', message: 'must be a number between -90 and 90', validator: 'latitude' }
+    ].forEach(config => {
+      it(`should add an error if ${config.problem}`, async function() {
+
+        const coordinates = [ 10, 20, 30, 40 ];
+        coordinates[config.index] = config.value;
+
+        const err = await validate(coordinates.join(','));
+        expect(err).not.to.equal(undefined);
+        expectErrors(err, [
+          {
+            location: `bbox[${config.index}]`,
+            message: config.message,
+            validator: config.validator,
+            value: config.value,
+            valueSet: true
+          }
+        ]);
+      });
+    })
+
+    async function validate(value) {
+
+      let validationError;
+      await dsl(function(ctx) {
+        ctx.set({
+          location: 'bbox'
+        });
+
+        return ctx.validate(ctx.value(value), ctx.while(ctx.noError(ctx.atCurrentLocation())), validateBboxString());
+      }).catch(err => validationError = err);
+
+      return validationError;
+    }
+  });
+
   describe('point', function() {
 
     const validatePoint = geoJsonValidators.point;

--- a/server/spec/fixtures/geojson.js
+++ b/server/spec/fixtures/geojson.js
@@ -63,7 +63,7 @@ exports.coordinates = function(data = {}) {
 };
 
 function ensureBbox(bbox) {
-  if (!bbox) {
+  if (!_.isObject(bbox)) {
     throw new Error('Bounding box must be an object');
   } else if (!bbox.southWest) {
     throw new Error('Bounding box must have a "southWest" property');
@@ -78,9 +78,7 @@ function ensureBbox(bbox) {
 }
 
 function ensureCoordinates(coordinates) {
-  if (!coordinates) {
-    throw new Error('Coordinates are required');
-  } else if (!_.isArray(coordinates)) {
+  if (!_.isArray(coordinates)) {
     throw new Error(`Coordinates must be an array, got ${typeof(coordinates)}`);
   } else if (coordinates.length != 2) {
     throw new Error(`Coordinates must be an array with 2 elements, but it has length ${coordinates.length}`);

--- a/server/spec/fixtures/geojson.js
+++ b/server/spec/fixtures/geojson.js
@@ -3,6 +3,7 @@
  *
  * @module server/spec/fixtures/geojson
  */
+const _ = require('lodash');
 const chance = require('chance').Chance();
 
 /**
@@ -11,13 +12,19 @@ const chance = require('chance').Chance();
  *     const geoJsonFixtures = require('../spec/fixtures/geojson');
  *
  *     geoJsonFixtures.point();  // { type: 'Point', coordinates: [ -76, 48 ] }
+ *     geoJsonFixtures.point({ coordinates });  // { type: 'Point', coordinates: [ -76, 48 ] }
  *
+ * @param {object} [data={}] - Custom point data.
+ * @param {object} [data.bbox] - A bounding box within which the generated point should be.
+ * @param {number[]} data.bbox.southWest - A longitude/latitude pair indicating the south-west corner of the bounding box.
+ * @param {number[]} data.bbox.northEast - A longitude/latitude pair indicating the north-east corner of the bounding box.
+ * @param {number[]} [data.coordinates] - The point's coordinates (longitude & latitude).
  * @returns {object} A GeoJSON point.
  */
-exports.point = function() {
+exports.point = function(data = {}) {
   return {
     type: 'Point',
-    coordinates: exports.coordinates()
+    coordinates: data.coordinates ? ensureCoordinates(data.coordinates) : exports.coordinates(_.pick(data, 'bbox'))
   };
 };
 
@@ -28,11 +35,71 @@ exports.point = function() {
  *
  *     geoJsonFixtures.coordinates();  // [ -76, 48 ]
  *
+ * @param {object} [data={}] - Custom coordinates data.
+ * @param {object} [data.bbox] - A bounding box within which the generated coordinates should be.
+ * @param {number[]} data.bbox.southWest - A longitude/latitude pair indicating the south-west corner of the bounding box.
+ * @param {number[]} data.bbox.northEast - A longitude/latitude pair indicating the north-east corner of the bounding box.
  * @returns {number[]} A GeoJSON coordinates pair.
  */
-exports.coordinates = function() {
+exports.coordinates = function(data = {}) {
+
+  let minLatitude = -90;
+  let maxLatitude = 90;
+  let minLongitude = -180;
+  let maxLongitude = 180;
+
+  if (data.bbox) {
+    const bbox = ensureBbox(data.bbox);
+    minLatitude = bbox.southWest[1];
+    maxLatitude = bbox.northEast[1];
+    minLongitude = bbox.southWest[0];
+    maxLongitude = bbox.northEast[0];
+  }
+
   return [
-    chance.floating({ min: -180, max: 180 }),
-    chance.floating({ min: -90, max: 90 })
+    chance.floating({ min: minLongitude, max: maxLongitude }),
+    chance.floating({ min: minLatitude, max: maxLatitude })
   ];
 };
+
+function ensureBbox(bbox) {
+  if (!bbox) {
+    throw new Error('Bounding box must be an object');
+  } else if (!bbox.southWest) {
+    throw new Error('Bounding box must have a "southWest" property');
+  } else if (!bbox.northEast) {
+    throw new Error('Bounding box must have a "northEast" property');
+  }
+
+  ensureCoordinates(bbox.southWest);
+  ensureCoordinates(bbox.northEast);
+
+  return bbox;
+}
+
+function ensureCoordinates(coordinates) {
+  if (!coordinates) {
+    throw new Error('Coordinates are required');
+  } else if (!_.isArray(coordinates)) {
+    throw new Error(`Coordinates must be an array, got ${typeof(coordinates)}`);
+  } else if (coordinates.length != 2) {
+    throw new Error(`Coordinates must be an array with 2 elements, but it has length ${coordinates.length}`);
+  }
+
+  const nan = coordinates.find(value => !_.isFinite(value))
+  if (nan !== undefined) {
+    throw new Error(`Coordinates must contain only numbers, got ${typeof(nan)}`);
+  }
+
+  const longitude = coordinates[0];
+  if (longitude < -180 || longitude > 180) {
+    throw new Error(`Longitude must be between -180 and 180, got ${longitude}`);
+  }
+
+  const latitude = coordinates[1];
+  if (latitude < -90 || latitude > 90) {
+    throw new Error(`Latitude must be between -90 and 90, got ${latitude}`);
+  }
+
+  return coordinates;
+}

--- a/server/spec/fixtures/geojson.spec.js
+++ b/server/spec/fixtures/geojson.spec.js
@@ -1,0 +1,101 @@
+const _ = require('lodash');
+
+const { expect } = require('../utils');
+const geoJsonFixtures = require('./geojson');
+
+describe('GeoJSON fixtures', () => {
+  describe('coordinates', () => {
+
+    const generateCoordinates = geoJsonFixtures.coordinates;
+
+    it('should generate random coordinates', () => {
+
+      const unique = [];
+      _.times(100, () => {
+
+        const coordinates = generateCoordinates();
+        expect(coordinates).to.be.an('array');
+        expect(coordinates).to.have.lengthOf(2);
+        expect(coordinates[0]).to.be.a('number');
+        expect(coordinates[0]).to.be.at.least(-180);
+        expect(coordinates[0]).to.be.at.most(180);
+        expect(coordinates[1]).to.be.a('number');
+        expect(coordinates[1]).to.be.at.least(-90);
+        expect(coordinates[1]).to.be.at.most(90);
+
+        const fingerprint = coordinates.join(',');
+        if (unique.indexOf(fingerprint) < 0) {
+          unique.push(fingerprint);
+        }
+      });
+
+      // Check that at least 90% of the coordinates are different
+      // (we can't be 100% sure that they all will be).
+      expect(unique).to.have.lengthOf.at.least(90);
+    });
+
+    describe('with the "bbox" option', () => {
+      it('should generate random coordinates within a bounding box', () => {
+
+        const bbox = {
+          southWest: [ 10, 20 ],
+          northEast: [ 20, 30 ]
+        };
+
+        const unique = [];
+        _.times(100, () => {
+
+          const coordinates = generateCoordinates({ bbox: bbox });
+          expect(coordinates).to.be.an('array');
+          expect(coordinates).to.have.lengthOf(2);
+          expect(coordinates[0]).to.be.a('number');
+          expect(coordinates[0]).to.be.at.least(10);
+          expect(coordinates[0]).to.be.at.most(20);
+          expect(coordinates[1]).to.be.a('number');
+          expect(coordinates[1]).to.be.at.least(20);
+          expect(coordinates[1]).to.be.at.most(30);
+
+          const fingerprint = coordinates.join(',');
+          if (unique.indexOf(fingerprint) < 0) {
+            unique.push(fingerprint);
+          }
+        });
+
+        // Check that at least 90% of the coordinates are different
+        // (we can't be 100% sure that they all will be).
+        expect(unique).to.have.lengthOf.at.least(90);
+      });
+
+      it('should not accept an invalid bounding box', () => {
+        expect(() => generateCoordinates({ bbox: 666 })).to.throw('Bounding box must be an object');
+      });
+
+      it('should not accept a bounding box with a missing corner', () => {
+        expect(() => generateCoordinates({ bbox: { southWest: [ 10, 20 ] } })).to.throw('Bounding box must have a "northEast" property');
+        expect(() => generateCoordinates({ bbox: { northEast: [ 20, 30 ] } })).to.throw('Bounding box must have a "southWest" property');
+      });
+
+      it('should not accept missing coordinates', () => {
+        expect(() => generateCoordinates({ bbox: { southWest: [ 10, 20 ], northEast: true } })).to.throw('Coordinates must be an array, got boolean');
+      });
+
+      it('should not accept the wrong number of coordinates', () => {
+        expect(() => generateCoordinates({ bbox: { southWest: [ 10, 20, 30 ], northEast: [ 20, 30 ] } })).to.throw('Coordinates must be an array with 2 elements, but it has length 3');
+      });
+
+      it('should not accept coordinates that are not numbers', () => {
+        expect(() => generateCoordinates({ bbox: { southWest: [ 'asd', 20 ], northEast: [ 20, 30 ] } })).to.throw('Coordinates must contain only numbers, got string');
+      });
+
+      it('should not accept a longitude that is out of bounds', () => {
+        expect(() => generateCoordinates({ bbox: { southWest: [ 1000, 20 ], northEast: [ 20, 30 ] } })).to.throw('Longitude must be between -180 and 180, got 1000');
+        expect(() => generateCoordinates({ bbox: { southWest: [ 10, 20 ], northEast: [ -200, 30 ] } })).to.throw('Longitude must be between -180 and 180, got -200');
+      });
+
+      it('should not accept a latitude that is out of bounds', () => {
+        expect(() => generateCoordinates({ bbox: { southWest: [ 10, 200 ], northEast: [ 20, 30 ] } })).to.throw('Latitude must be between -90 and 90, got 200');
+        expect(() => generateCoordinates({ bbox: { southWest: [ 10, 20 ], northEast: [ 20, -90.5 ] } })).to.throw('Latitude must be between -90 and 90, got -90.5');
+      });
+    })
+  });
+});

--- a/server/spec/fixtures/location.js
+++ b/server/spec/fixtures/location.js
@@ -28,6 +28,9 @@ const geoJsonFixtures = require('./geojson');
  *
  * @function
  * @param {object} [data={}] - Custom location data.
+ * @param {object} [data.bbox] - A bounding box within which the generated location should be
+ * @param {number[]} data.bbox.southWest - A longitude/latitude pair indicating the south-west corner of the bounding box
+ * @param {number[]} data.bbox.northEast - A longitude/latitude pair indicating the north-east corner of the bounding box
  * @param {string} [data.name]
  * @param {string} [data.shortName] - Set to `null` to create a location without a short name.
  * @param {string} [data.description]
@@ -52,7 +55,7 @@ exports.location = function(data = {}) {
     phone: data.phone || chance.phone(),
     photo_url: data.phoneUrl || chance.url({ domain: 'example.com', extensions: [ 'jpg' ] }),
     site_url: data.siteUrl || chance.url({ domain: 'example.com' }),
-    geometry: data.geometry || geoJsonFixtures.point(),
+    geometry: data.geometry || geoJsonFixtures.point(_.pick(data, 'bbox')),
     properties: data.properties || {},
     address_street: _.get(data, 'address.street', chance.street()),
     address_number: _.get(data, 'address.number', chance.integer({ min: 1, max: 100 }).toString()),

--- a/server/utils/jwt.js
+++ b/server/utils/jwt.js
@@ -44,7 +44,7 @@ exports.generateToken = function(properties) {
 
   if (jwtOptions.exp === undefined) {
     throw new Error(`JWT "exp" option is required`);
-  } else if (!_.isNumber(jwtOptions.exp)) {
+  } else if (!_.isFinite(jwtOptions.exp)) {
     throw new Error(`JWT "exp" option must be a number, got ${jwtOptions.exp} (${typeof(jwtOptions.exp)})`);
   } else if (jwtOptions.exp <= 0) {
     throw new Error(`JWT "exp" option must be greater than zero, got ${jwtOptions.exp}`);


### PR DESCRIPTION
The sample data script has been updated to generate 50 random locations
in Onex.

To validate the `bbox` query parameter, a new `bboxString` validator has
been implemented. Additionally, a new `query` ValDSL function has been
added to navigate query parameters during validation.

A few `typeof(value) != 'number'` and `!_.isNumber(value)` checks have
been replaced by the more precise `!_.isFinite(value)`. The former
accepts `Infinity` and `NaN` as numbers (yes, `typeof(NaN) == 'number'`,
thank you JavaScript).

Story: TG-43