### PR TITLE
Handle method not allowed on routes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -92,7 +92,7 @@ from being split into one file for each route for readability.
 | `{subject}/{subject}.api.js`      | Route implementations and other middlewares related to the subject                                  |
 | `{subject}/{subject}.api.spec.js` | Automated tests for the routes                                                                      |
 | `{subject}/{subject}.policy.js`   | Default authorization policy for the subject's resources (handling access, parsing and serializing) |
-| `{subject}/{subject}.routes.js`   | Express router and route definitions (including authentication and authorization)                   |
+| `{subject}/{subject}.routes.js`   | Express router and route definitions (including authentication, authorization and methods not allowed)                   |
 | `{subject}/{subject}.raml`        | API documentation for the routes                                                                    |
 | `{subject}/{subject}.model.raml`  | API documentation for the main model/resource used in this subject                                  |
 

--- a/server/api/auth/auth.api.spec.js
+++ b/server/api/auth/auth.api.spec.js
@@ -7,7 +7,7 @@ const config = require('../../../config');
 const User = require('../../models/user');
 const expectUser = require('../../spec/expectations/user');
 const userFixtures = require('../../spec/fixtures/user');
-const { cleanDatabase, expect, expectErrors, expectMethodsNotAllowed, initSuperRest, setUp } = require('../../spec/utils');
+const { cleanDatabase, expect, expectErrors, initSuperRest, setUp, testMethodsNotAllowed } = require('../../spec/utils');
 
 setUp();
 
@@ -22,7 +22,7 @@ describe('Authentication API', function() {
   });
 
   describe('/api/auth', () => {
-    expectMethodsNotAllowed('/auth', require('../auth/auth.routes').allowedMethods['/']);
+    testMethodsNotAllowed('/auth', require('../auth/auth.routes').allowedMethods['/']);
   });
 
   describe('POST /api/auth', () => {

--- a/server/api/auth/auth.api.spec.js
+++ b/server/api/auth/auth.api.spec.js
@@ -7,7 +7,7 @@ const config = require('../../../config');
 const User = require('../../models/user');
 const expectUser = require('../../spec/expectations/user');
 const userFixtures = require('../../spec/fixtures/user');
-const { cleanDatabase, expect, expectErrors, initSuperRest, setUp } = require('../../spec/utils');
+const { cleanDatabase, expect, expectErrors, expectMethodsNotAllowed, initSuperRest, setUp } = require('../../spec/utils');
 
 setUp();
 
@@ -19,6 +19,10 @@ describe('Authentication API', function() {
     await cleanDatabase();
     now = new Date();
     twoDaysAgo = moment().subtract(2, 'days').toDate();
+  });
+
+  describe('/api/auth', () => {
+    expectMethodsNotAllowed('/auth', require('../auth/auth.routes').allowedMethods['/']);
   });
 
   describe('POST /api/auth', () => {

--- a/server/api/auth/auth.routes.js
+++ b/server/api/auth/auth.routes.js
@@ -1,14 +1,23 @@
 const express = require('express');
 
+const api = require('../utils/api');
 const auth = require('../utils/auth');
 const controller = require('./auth.api');
 const policy = require('./auth.policy');
 
 const router = express.Router();
 
+const allowedMethods = {
+  '/': ['POST']
+};
+
 // POST /api/auth
 router.post('/',
   auth.authorize(policy.canAuthenticate, { authenticate: false }),
   controller.authenticate);
 
-module.exports = router;
+// Handles unallowed HTTP methods on /
+router.use('/', api.allowsOnlyMethod(allowedMethods['/']));
+
+exports.router = router;
+exports.allowedMethods = allowedMethods;

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -15,10 +15,10 @@ const modelFiles = _.without(glob.sync('*', { cwd: config.path('server', 'models
 modelFiles.forEach(modelFile => require(`../models/${modelFile}`));
 
 // Plug in API routes.
-router.use('/auth', require('./auth/auth.routes'));
-router.use('/locations', require('./locations/locations.routes'));
-router.use('/me', require('./users/users.me.routes'));
-router.use('/users', require('./users/users.routes'));
+router.use('/auth', require('./auth/auth.routes').router);
+router.use('/locations', require('./locations/locations.routes').router);
+router.use('/me', require('./users/users.me.routes').router);
+router.use('/users', require('./users/users.routes').router);
 
 // Return API metadata on the main API route.
 router.get('/', function(req, res) {
@@ -40,6 +40,11 @@ router.use(function(err, req, res, next) {
   // Log the error if unexpected
   if (status >= 500 && status <= 599) {
     logger.error(err);
+  }
+
+  // Sets the headers if the received error has some
+  if (err.headers) {
+    _.each(err.headers, (value, name) => res.set(name, value));
   }
 
   let errors;

--- a/server/api/locations/locations.api.spec.js
+++ b/server/api/locations/locations.api.spec.js
@@ -7,7 +7,7 @@ const expectLocation = require('../../spec/expectations/location');
 const geoJsonFixtures = require('../../spec/fixtures/geojson');
 const locationFixtures = require('../../spec/fixtures/location');
 const userFixtures = require('../../spec/fixtures/user');
-const { cleanDatabase, expect, expectDeleted, expectErrors, expectUnchanged, initSuperRest, setUp, expectMethodsNotAllowed } = require('../../spec/utils');
+const { cleanDatabase, expect, expectDeleted, expectErrors, expectUnchanged, initSuperRest, setUp, testMethodsNotAllowed } = require('../../spec/utils');
 
 setUp();
 
@@ -21,7 +21,7 @@ describe('Locations API', function() {
   });
 
   describe('/api/locations', function() {
-    expectMethodsNotAllowed('/locations', require('../locations/locations.routes').allowedMethods['/']);
+    testMethodsNotAllowed('/locations', require('../locations/locations.routes').allowedMethods['/']);
   });
 
   describe('POST /api/locations', function() {
@@ -505,7 +505,7 @@ describe('Locations API', function() {
   });
 
   describe('/api/locations/:id', function() {
-    expectMethodsNotAllowed('/locations/1', require('../locations/locations.routes').allowedMethods['/:id']);
+    testMethodsNotAllowed('/locations/1', require('../locations/locations.routes').allowedMethods['/:id']);
   });
 
   describe('GET /api/locations/:id', function() {

--- a/server/api/locations/locations.api.spec.js
+++ b/server/api/locations/locations.api.spec.js
@@ -7,16 +7,21 @@ const expectLocation = require('../../spec/expectations/location');
 const geoJsonFixtures = require('../../spec/fixtures/geojson');
 const locationFixtures = require('../../spec/fixtures/location');
 const userFixtures = require('../../spec/fixtures/user');
-const { cleanDatabase, expect, expectDeleted, expectErrors, expectUnchanged, initSuperRest, setUp } = require('../../spec/utils');
+const { cleanDatabase, expect, expectDeleted, expectErrors, expectUnchanged, initSuperRest, setUp, expectMethodsNotAllowed } = require('../../spec/utils');
 
 setUp();
 
 describe('Locations API', function() {
 
   let api, now, reqBody;
+
   beforeEach(async function() {
     api = initSuperRest();
     await cleanDatabase();
+  });
+
+  describe('/api/locations', function() {
+    expectMethodsNotAllowed('/locations', require('../locations/locations.routes').allowedMethods['/']);
   });
 
   describe('POST /api/locations', function() {
@@ -32,7 +37,7 @@ describe('Locations API', function() {
         siteUrl: 'http://example.com',
         geometry: {
           type: 'Point',
-          coordinates: [ -73.957820, 40.772317 ]
+          coordinates: [-73.957820, 40.772317]
         },
         address: {
           street: 'Riverside Drive',
@@ -82,7 +87,7 @@ describe('Locations API', function() {
 
         await expectLocation(res.body, getExpectedLocationFromRequestBody({
           properties: {},
-          createdAt: [ 'gt', now, 500 ],
+          createdAt: ['gt', now, 500],
           updatedAt: 'createdAt'
         }));
       });
@@ -93,7 +98,7 @@ describe('Locations API', function() {
         reqBody.address.number = '210';
         reqBody.properties = {
           foo: 'bar',
-          bar: [ 'baz', 'qux' ]
+          bar: ['baz', 'qux']
         };
 
         const res = this.test.res = await api
@@ -101,7 +106,7 @@ describe('Locations API', function() {
           .set('Authorization', `Bearer ${admin.generateJwt()}`);
 
         await expectLocation(res.body, getExpectedLocationFromRequestBody({
-          createdAt: [ 'gt', now, 500 ],
+          createdAt: ['gt', now, 500],
           updatedAt: 'createdAt'
         }));
       });
@@ -218,9 +223,9 @@ describe('Locations API', function() {
         reqBody.address.zipCode = '12345678901234567';
         reqBody.geometry = {
           type: 'MultiLineString',
-          coordinates: [ 'foo', 666 ]
+          coordinates: ['foo', 666]
         };
-        reqBody.properties = [ 'foo' ];
+        reqBody.properties = ['foo'];
 
         const res = this.test.res = await api
           .create('/locations', reqBody, { expectedStatus: 422 })
@@ -239,7 +244,7 @@ describe('Locations API', function() {
             type: 'json',
             location: '/phone',
             validator: 'type',
-            types: [ 'string' ],
+            types: ['string'],
             value: 5550001,
             valueSet: true
           },
@@ -248,7 +253,7 @@ describe('Locations API', function() {
             type: 'json',
             location: '/siteUrl',
             validator: 'type',
-            types: [ 'string' ],
+            types: ['string'],
             value: false,
             valueSet: true
           },
@@ -257,8 +262,8 @@ describe('Locations API', function() {
             type: 'json',
             location: '/properties',
             validator: 'type',
-            types: [ 'object' ],
-            value: [ 'foo' ],
+            types: ['object'],
+            value: ['foo'],
             valueSet: true
           },
           {
@@ -330,7 +335,7 @@ describe('Locations API', function() {
             message: 'must be of type number',
             type: 'json',
             location: '/geometry/coordinates/0',
-            types: [ 'number' ],
+            types: ['number'],
             validator: 'type',
             value: 'foo',
             valueSet: true
@@ -418,9 +423,9 @@ describe('Locations API', function() {
       let locations;
       beforeEach(async function() {
         locations = await Promise.all([
-          locationFixtures.location({ name: 'Location A - Somewhere', geometry: geoJsonFixtures.point({ bbox: { southWest: [ 9, 19 ], northEast: [ 11, 21 ] } }) }),
-          locationFixtures.location({ name: 'Location C - Somewhere else', geometry: geoJsonFixtures.point({ bbox: { southWest: [ 19, 29 ], northEast: [ 21, 31 ] } }) }),
-          locationFixtures.location({ name: 'Location B - Somewhere precise', geometry: geoJsonFixtures.point({ coordinates: [ 30, 40 ] }) })
+          locationFixtures.location({ name: 'Location A - Somewhere', geometry: geoJsonFixtures.point({ bbox: { southWest: [9, 19], northEast: [11, 21] } }) }),
+          locationFixtures.location({ name: 'Location C - Somewhere else', geometry: geoJsonFixtures.point({ bbox: { southWest: [19, 29], northEast: [21, 31] } }) }),
+          locationFixtures.location({ name: 'Location B - Somewhere precise', geometry: geoJsonFixtures.point({ coordinates: [30, 40] }) })
         ]);
       });
 
@@ -497,6 +502,10 @@ describe('Locations API', function() {
         ]);
       });
     });
+  });
+
+  describe('/api/locations/:id', function() {
+    expectMethodsNotAllowed('/locations/1', require('../locations/locations.routes').allowedMethods['/:id']);
   });
 
   describe('GET /api/locations/:id', function() {
@@ -615,7 +624,7 @@ describe('Locations API', function() {
           .set('Authorization', `Bearer ${admin.generateJwt()}`);
 
         expectLocation(res.body, getExpectedLocation(location, reqBody, {
-          updatedAt: [ 'gte', now, 500 ]
+          updatedAt: ['gte', now, 500]
         }));
       });
 
@@ -626,7 +635,7 @@ describe('Locations API', function() {
           shortName: chance.word(),
           description: chance.paragraph(),
           phone: chance.phone(),
-          photoUrl: chance.url({ extensions: [ 'png' ] }),
+          photoUrl: chance.url({ extensions: ['png'] }),
           siteUrl: chance.url(),
           geometry: geoJsonFixtures.point(),
           properties: {
@@ -646,7 +655,7 @@ describe('Locations API', function() {
           .set('Authorization', `Bearer ${admin.generateJwt()}`);
 
         expectLocation(res.body, getExpectedLocation(location, reqBody, {
-          updatedAt: [ 'gte', now, 500 ]
+          updatedAt: ['gte', now, 500]
         }));
       });
 
@@ -665,7 +674,7 @@ describe('Locations API', function() {
           .set('Authorization', `Bearer ${admin.generateJwt()}`);
 
         expectLocation(res.body, getExpectedLocation(location, reqBody, {
-          updatedAt: [ 'gte', now, 500 ]
+          updatedAt: ['gte', now, 500]
         }));
       });
 
@@ -692,9 +701,9 @@ describe('Locations API', function() {
           },
           geometry: {
             type: 'MultiLineString',
-            coordinates: [ 'foo', 666 ]
+            coordinates: ['foo', 666]
           },
-          properties: [ 'foo' ]
+          properties: ['foo']
         };
 
         const res = this.test.res = await api
@@ -707,7 +716,7 @@ describe('Locations API', function() {
             type: 'json',
             location: '/phone',
             validator: 'type',
-            types: [ 'string' ],
+            types: ['string'],
             value: 5550001,
             valueSet: true
           },
@@ -716,7 +725,7 @@ describe('Locations API', function() {
             type: 'json',
             location: '/siteUrl',
             validator: 'type',
-            types: [ 'string' ],
+            types: ['string'],
             value: false,
             valueSet: true
           },
@@ -725,8 +734,8 @@ describe('Locations API', function() {
             type: 'json',
             location: '/properties',
             validator: 'type',
-            types: [ 'object' ],
-            value: [ 'foo' ],
+            types: ['object'],
+            value: ['foo'],
             valueSet: true
           },
           {
@@ -791,7 +800,7 @@ describe('Locations API', function() {
             message: 'must be of type number',
             type: 'json',
             location: '/geometry/coordinates/0',
-            types: [ 'number' ],
+            types: ['number'],
             validator: 'type',
             value: 'foo',
             valueSet: true
@@ -811,7 +820,7 @@ describe('Locations API', function() {
 
         reqBody = {
           geometry: {
-            coordinates: [ 99, 66 ]
+            coordinates: [99, 66]
           }
         };
 
@@ -825,10 +834,10 @@ describe('Locations API', function() {
           location: '/geometry',
           validator: 'properties',
           cause: 'missingProperties',
-          expectedProperties: [ 'type', 'coordinates' ],
-          missingProperties: [ 'type' ],
-          value: { coordinates: [ 99, 66 ] },
-          valueSet:true
+          expectedProperties: ['type', 'coordinates'],
+          missingProperties: ['type'],
+          value: { coordinates: [99, 66] },
+          valueSet: true
         });
       });
     });

--- a/server/api/locations/locations.routes.js
+++ b/server/api/locations/locations.routes.js
@@ -1,10 +1,16 @@
 const express = require('express');
 
+const api = require('../utils/api');
 const auth = require('../utils/auth');
 const controller = require('./locations.api');
 const policy = require('./locations.policy');
 
 const router = express.Router();
+
+const allowedMethods = {
+  '/': [ 'GET', 'POST' ],
+  '/:id': [ 'GET', 'PATCH', 'DELETE' ]
+};
 
 // POST /api/locations
 router.post('/',
@@ -34,4 +40,10 @@ router.delete('/:id',
   auth.authorize(policy.canDestroy),
   controller.destroy);
 
-module.exports = router;
+// Handle unallowed HTTP methids on /:id
+router.use('/:id', api.allowsOnlyMethod(allowedMethods[ '/:id' ]));
+// Handle unallowed HTTP methods on /
+router.use('/', api.allowsOnlyMethod(allowedMethods[ '/' ]));
+
+exports.router = router;
+exports.allowedMethods = allowedMethods;

--- a/server/api/users/users.api.spec.js
+++ b/server/api/users/users.api.spec.js
@@ -4,7 +4,7 @@ const moment = require('moment');
 const User = require('../../models/user');
 const expectUser = require('../../spec/expectations/user');
 const userFixtures = require('../../spec/fixtures/user');
-const { cleanDatabase, expect, expectErrors, initSuperRest, setUp } = require('../../spec/utils');
+const { cleanDatabase, expect, expectErrors, initSuperRest, setUp, expectMethodsNotAllowed } = require('../../spec/utils');
 
 setUp();
 
@@ -15,6 +15,10 @@ describe('Users API', function() {
     api = initSuperRest();
     await cleanDatabase();
     twoDaysAgo = moment().subtract(2, 'days').toDate();
+  });
+
+  describe('/api/users/:id', function() {
+    expectMethodsNotAllowed('/users/:id', require('../users/users.routes').allowedMethods['/:id']);
   });
 
   describe('GET /api/users/:id', function() {
@@ -113,6 +117,10 @@ describe('Users API', function() {
         });
       });
     });
+  });
+
+  describe('/api/me', function() {
+    expectMethodsNotAllowed('/me', require('../users/users.me.routes').allowedMethods['/']);
   });
 
   describe('GET /api/me', function() {

--- a/server/api/users/users.api.spec.js
+++ b/server/api/users/users.api.spec.js
@@ -4,7 +4,7 @@ const moment = require('moment');
 const User = require('../../models/user');
 const expectUser = require('../../spec/expectations/user');
 const userFixtures = require('../../spec/fixtures/user');
-const { cleanDatabase, expect, expectErrors, initSuperRest, setUp, expectMethodsNotAllowed } = require('../../spec/utils');
+const { cleanDatabase, expect, expectErrors, initSuperRest, setUp, testMethodsNotAllowed } = require('../../spec/utils');
 
 setUp();
 
@@ -18,7 +18,7 @@ describe('Users API', function() {
   });
 
   describe('/api/users/:id', function() {
-    expectMethodsNotAllowed('/users/:id', require('../users/users.routes').allowedMethods['/:id']);
+    testMethodsNotAllowed('/users/:id', require('../users/users.routes').allowedMethods['/:id']);
   });
 
   describe('GET /api/users/:id', function() {
@@ -120,7 +120,7 @@ describe('Users API', function() {
   });
 
   describe('/api/me', function() {
-    expectMethodsNotAllowed('/me', require('../users/users.me.routes').allowedMethods['/']);
+    testMethodsNotAllowed('/me', require('../users/users.me.routes').allowedMethods['/']);
   });
 
   describe('GET /api/me', function() {

--- a/server/api/users/users.me.routes.js
+++ b/server/api/users/users.me.routes.js
@@ -1,10 +1,15 @@
 const express = require('express');
 
+const api = require('../utils/api');
 const auth = require('../utils/auth');
 const controller = require('./users.api');
 const policy = require('./users.policy');
 
 const router = express.Router();
+
+const allowedMethods = {
+  '/': ['GET']
+}
 
 // GET /api/me
 router.get('/',
@@ -13,4 +18,7 @@ router.get('/',
   auth.authorize(policy.canRetrieve, { authenticate: false }),
   controller.retrieve);
 
-module.exports = router;
+router.use('/', api.allowsOnlyMethod(allowedMethods['/']));
+
+exports.router = router;
+exports.allowedMethods = allowedMethods;

--- a/server/api/users/users.routes.js
+++ b/server/api/users/users.routes.js
@@ -1,10 +1,15 @@
 const express = require('express');
 
+const api = require('../utils/api');
 const auth = require('../utils/auth');
 const controller = require('./users.api');
 const policy = require('./users.policy');
 
 const router = express.Router();
+
+const allowedMethods = {
+  '/:id': [ 'GET' ]
+}
 
 // GET /api/users/:id
 router.get('/:id',
@@ -13,4 +18,8 @@ router.get('/:id',
   auth.authorize(policy.canRetrieve, { authenticate: false, resourceName: controller.resourceName }),
   controller.retrieve);
 
-module.exports = router;
+// Handles unallowed HTTP method on /api/users/:id
+router.use('/:id', api.allowsOnlyMethod(allowedMethods['/:id']));
+
+exports.router = router;
+exports.allowedMethods = allowedMethods;

--- a/server/spec/utils.js
+++ b/server/spec/utils.js
@@ -40,10 +40,10 @@ const expect = exports.expect = chai.expect;
  * @param {string} path - The path to test
  * @param {array} allowedMethods - An array of the methods to test on the path
  */
-exports.expectMethodsNotAllowed = async function(path, allowedMethods) {
-  const methodToTest = _.difference(httpMethods, allowedMethods);
+exports.testMethodsNotAllowed = async function(path, allowedMethods) {
+  const methodsToTest = _.difference(httpMethods, allowedMethods);
 
-  _.each(methodToTest, method => {
+  _.each(methodsToTest, method => {
     it(`should not allow request with ${method} method`, async function() {
       const res = this.test.res = await exports.initSuperRest().test(method, path, {}, { expectedStatus: 405 });
 


### PR DESCRIPTION
Added a new mechanism to handle methods that are not allowed on a specific
route.

This introduces several things:

A new error, called `methodNotAllowed` that sends a 405 HTTP code with
the appropriate header.

This error is called by a middleware, `allowsOnylMethod` in the
`server/api/utils/api.js` file.

This middleware is then used in each `*.routes.js` file, which have
changed a little.
Now, they exports two things :
* The router for this resource
* An object listing the methods allowed on each route

New tests have been added on the test suite for each resource API that
tests that it correctly reject any request on a route with an unallowed
HTTP methods.