### PR TITLE
Document API Error

### DIFF
--- a/server/api/index.raml
+++ b/server/api/index.raml
@@ -5,7 +5,7 @@ baseUri: https://biopocket.ch/api
 version: 1
 mediaType: application/json
 documentation:
-  - !include raml/api-error-codes.raml
+  - !include raml/api-errors.raml
 
 traits:
   authenticatedResource: !include raml/traits/authenticated-resource.raml

--- a/server/api/index.raml
+++ b/server/api/index.raml
@@ -4,6 +4,8 @@ title: BioPocket
 baseUri: https://biopocket.ch/api
 version: 1
 mediaType: application/json
+documentation:
+  - !include raml/api-error-codes.raml
 
 traits:
   authenticatedResource: !include raml/traits/authenticated-resource.raml

--- a/server/api/locations/locations.api.spec.js
+++ b/server/api/locations/locations.api.spec.js
@@ -522,7 +522,7 @@ describe('Locations API', function() {
 
     it('should retrieve a location', async function() {
       const res = this.test.res = await api.retrieve(`/locations/${location.get('api_id')}`);
-      expectLocation(res.body, getExpectedLocation(location));
+      await expectLocation(res.body, getExpectedLocation(location));
     });
 
     it('should not retrieve a location that does not exist', async function() {
@@ -560,7 +560,7 @@ describe('Locations API', function() {
           .retrieve(`/locations/${location.get('api_id')}`)
           .set('Authorization', `Bearer ${user.generateJwt()}`);
 
-        expectLocation(res.body, getExpectedLocation(location));
+        await expectLocation(res.body, getExpectedLocation(location));
       });
     });
   });
@@ -628,7 +628,7 @@ describe('Locations API', function() {
           .patch(`/locations/${location.get('api_id')}`, reqBody)
           .set('Authorization', `Bearer ${admin.generateJwt()}`);
 
-        expectLocation(res.body, getExpectedLocation(location, reqBody, {
+        await expectLocation(res.body, getExpectedLocation(location, reqBody, {
           updatedAt: [ 'gte', now, 500 ]
         }));
       });
@@ -659,7 +659,7 @@ describe('Locations API', function() {
           .patch(`/locations/${location.get('api_id')}`, reqBody)
           .set('Authorization', `Bearer ${admin.generateJwt()}`);
 
-        expectLocation(res.body, getExpectedLocation(location, reqBody, {
+        await expectLocation(res.body, getExpectedLocation(location, reqBody, {
           updatedAt: [ 'gte', now, 500 ]
         }));
       });
@@ -678,7 +678,7 @@ describe('Locations API', function() {
           .patch(`/locations/${location.get('api_id')}`, reqBody)
           .set('Authorization', `Bearer ${admin.generateJwt()}`);
 
-        expectLocation(res.body, getExpectedLocation(location, reqBody, {
+        await expectLocation(res.body, getExpectedLocation(location, reqBody, {
           updatedAt: [ 'gte', now, 500 ]
         }));
       });
@@ -689,7 +689,7 @@ describe('Locations API', function() {
           .patch(`/locations/${location.get('api_id')}`, {})
           .set('Authorization', `Bearer ${admin.generateJwt()}`);
 
-        expectLocation(res.body, getExpectedLocation(location));
+        await expectLocation(res.body, getExpectedLocation(location));
       });
 
       it('should not accept invalid properties', async function() {

--- a/server/api/raml/api-error-codes.raml
+++ b/server/api/raml/api-error-codes.raml
@@ -1,9 +1,0 @@
-title: API Error codes
-content: |
-  * `auth.invalidAuthorization` - The authentication failed due to credentials being invalid or expired.
-  * `auth.forbidden` - You don't have authorization to access the requested resource.
-  * `auth.malformedAuthorization` - The authentication failed due to credentials having unexpected values or format.
-  * `auth.missingAuthorization` - THe authentication failed due to missing credentials in the request.
-  * `method.notAllowed` - The resource you tried to access does not support the used HTTP method.
-  * `record.notFound` - The record you tried to retrieve does not exist or you don't have authorization to access it.
-  * `resource.notFound` - There is no resource available for this URL and HTTP method.

--- a/server/api/raml/api-error-codes.raml
+++ b/server/api/raml/api-error-codes.raml
@@ -1,0 +1,9 @@
+title: API Error codes
+content: |
+  * `auth.invalidAuthorization` - The authentication failed due to credentials being invalid or expired.
+  * `auth.forbidden` - You don't have authorization to access the requested resource.
+  * `auth.malformedAuthorization` - The authentication failed due to credentials having unexpected values or format.
+  * `auth.missingAuthorization` - THe authentication failed due to missing credentials in the request.
+  * `method.notAllowed` - The resource you tried to access does not support the used HTTP method.
+  * `record.notFound` - The record you tried to retrieve does not exist or you don't have authorization to access it.
+  * `resource.notFound` - There is no resource available for this URL and HTTP method.

--- a/server/api/raml/api-errors.raml
+++ b/server/api/raml/api-errors.raml
@@ -1,0 +1,28 @@
+title: API Errors
+content: |
+  When a client or server error occurs, the API always sends a response in the same format:
+  a JSON object with an `errors` array containing one or more elements.
+  Each element of the array is an object describing a problem, for example:
+
+  ```json
+  {
+    "errors": [
+      {
+        "code": "auth.forbidden",
+        "message": "You are not authorized to access this resource."
+      }
+    ]
+  }
+  ```
+
+  Some of these errors are identified by a `code` property which you can use to identify the problem:
+
+  | Code                          | Problem                                                                                                                                                       |
+  | :---                          | :---                                                                                                                                                          |
+  | `auth.invalidAuthorization`   | The authentication failed because the bearer token sent in the `Authorization` header is invalid or has expired.                                              |
+  | `auth.forbidden`              | You have been successfully authenticated, but are not authorized to access the requested resource. Authenticate with a user account that has more privileges. |
+  | `auth.malformedAuthorization` | The authentication failed because the `Authorization` header does not have the correct format (`Bearer TOKEN`).                                               |
+  | `auth.missingAuthorization`   | The authentication failed because no `Authorization` header was sent.                                                                                         |
+  | `method.notAllowed`           | The resource you tried to access does not support the request's HTTP method.                                                                                  |
+  | `record.notFound`             | The record you tried to retrieve does not exist or you don't have authorization to access it.                                                                 |
+  | `resource.notFound`           | There is no resource available for this URL and HTTP method.                                                                                                  |

--- a/server/spec/expectations/location.js
+++ b/server/spec/expectations/location.js
@@ -8,7 +8,7 @@ module.exports = async function(actual, expected) {
   expect(actual, 'res.body').to.be.an('object');
 
   const expectedKeys = [ 'id', 'name', 'description', 'phone', 'photoUrl', 'siteUrl', 'geometry', 'address', 'properties', 'createdAt', 'updatedAt' ];
-  if (_.has(expected, 'shortName')) {
+  if (!_.isNil(expected.shortName)) {
     expectedKeys.push('shortName');
   }
 


### PR DESCRIPTION
A new `documentation` section has been added to the documentation, that
lists and explains all error code that could be returned by the API.

Also, updated some tests that were missing the `await` keyword, and fixed
an issue with a Location test.

TASK : TG-150